### PR TITLE
restore "jalr $rs" pseudoinstruction

### DIFF
--- a/architecture/MIPS-32-like.json
+++ b/architecture/MIPS-32-like.json
@@ -5204,7 +5204,7 @@
           "stopbit": "16"
         }
       ],
-      "definition": "rs=PC+4\nPC=addr"
+      "definition": "jalr $rs $ra;"
     },
     {
       "name": "li",


### PR DESCRIPTION
restore "jalr $rs" pseudoinstruction to the original "jalr $rs $ra;"